### PR TITLE
feat: Implement LeafNode class with HTML rendering

### DIFF
--- a/src/htmlnode.py
+++ b/src/htmlnode.py
@@ -26,3 +26,22 @@ class HTMLNode:
 
     def __repr__(self) -> str:
         return f"HTMLNode({self.tag}, {self.value}, {self.children}, {self.props})"
+
+
+class LeafNode(HTMLNode):
+    def __init__(
+        self,
+        tag: Optional[str] = None,
+        value: Optional[str] = None,
+        props: Optional[dict[str, str]] = None,
+    ):
+        super().__init__(tag=tag, value=value, children=None, props=props)
+
+    def to_html(self) -> str:
+        if self.value == None:
+            raise ValueError()
+
+        if self.tag == None:
+            return self.value
+
+        return f"<{self.tag}>{self.value}</{self.tag}>"

--- a/src/test_leafnode.py
+++ b/src/test_leafnode.py
@@ -1,0 +1,28 @@
+import unittest
+from htmlnode import LeafNode
+
+
+class TestLeafNode(unittest.TestCase):
+
+    def test_leaf_to_html_p(self):
+        node = LeafNode("p", "Hello, world!")
+        self.assertEqual(node.to_html(), "<p>Hello, world!</p>")
+
+    def test_initialization_with_valid_parameters(self):
+        node = LeafNode(tag="p", value="Sample text")
+        self.assertEqual(node.tag, "p")
+        self.assertEqual(node.value, "Sample text")
+        self.assertIsNone(node.children)
+
+    def test_initialization_with_none_value(self):
+        with self.assertRaises(ValueError):
+            leaf_node = LeafNode(tag="p", value=None)
+            leaf_node.to_html()  # Should raise ValueError
+
+    def test_to_html_with_tag(self):
+        node = LeafNode(tag="p", value="Hello, world!")
+        self.assertEqual(node.to_html(), "<p>Hello, world!</p>")
+
+    def test_to_html_without_tag(self):
+        node = LeafNode(tag=None, value="Just text")
+        self.assertEqual(node.to_html(), "Just text")


### PR DESCRIPTION
- Created `LeafNode` class as a child of `HTMLNode`
- Ensured `LeafNode` cannot have children and requires a value
- Implemented `.to_html()` method for HTML rendering
- Added unit tests for `LeafNode` with various tag types
- Verified all tests pass successfully